### PR TITLE
+ add ability to include header .tex files

### DIFF
--- a/inst/rmarkdown/templates/pnas_article/resources/template.tex
+++ b/inst/rmarkdown/templates/pnas_article/resources/template.tex
@@ -17,6 +17,10 @@ $if(tables)$
 \usepackage{longtable}
 $endif$
 
+$for(header-includes)$
+$header-includes$
+$endfor$
+
 $if(pnas_type)$
 \templatetype{$pnas_type$}  % Choose template
 $else$


### PR DESCRIPTION
Hi,

I've included the ability to add in custom `.tex` header files. This is done using the typical method for including header files in rmarkdown documents. Although this could be used to modify the document substantially from the PNAS template and defeat the purpose of using the template, I think some level of customisation is helpful (eg. defining new commands or loading in additional packages).

For example to include file `preamble.tex` in the resulting `.tex` file, the following YAML header would be used:

```
---
...
normal YAML header
...
output:
  rticles::pnas_article:
    includes:
      in_header: [preamble.tex]
---
```